### PR TITLE
Python3.5 でユニットテストが失敗する問題の修正。

### DIFF
--- a/pymcbdsc/__init__.py
+++ b/pymcbdsc/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 import docker
 from docker.client import DockerClient
 import requests
@@ -440,7 +440,7 @@ class McbdscDockerManager(object):
         """
         versions.sort(key=lambda s: list(map(int, s.split('.'))), reverse=reverse)
 
-    def get_bds_latest_version_from_local_file(self) -> str:
+    def get_bds_latest_version_from_local_file(self) -> Optional[str]:
         """ ローカルに保存されている BDS Zip ファイルの中で最も新しいバージョンを戻すメソッド。
 
         Returns:


### PR DESCRIPTION
Python3.5 では変数の型ヒントに対応していないようだったので、変数の型ヒントを削除。

(関数やメソッドの引数の型ヒントは継続。)