### PR TITLE
基本的な BDS の起動機能を追加、他

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           pkg-manager: pip
           pip-dependency-file: pymcbdsc.egg-info/requires.txt
       - run:
-          command: ./manage.py test
+          command: ./setup.py test
           name: Test
       - save_cache:
           key: v1-{{ .Branch }}-{{ .Revision }}
@@ -27,7 +27,7 @@ jobs:
     executor: python/default
     steps:
       - run:
-          command: ./manage.py test
+          command: ./setup.py test
           name: Test
   register:
     executor: python/default

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Python: unittest",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}/manage.py",
+            "program": "${workspaceFolder}/setup.py",
             "args": [
                 "test"
             ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pymcbdsc
 
+[![Version](https://badge.fury.io/py/pymcbdsc.svg)](https://pypi.org/project/pymcbdsc/) [![CircleCI](https://circleci.com/gh/ktooi/pymcbdsc/tree/main.svg?style=shield)](https://circleci.com/gh/ktooi/pymcbdsc/tree/main)
+
 Pymcbdsc(Python Minecraft Bedrock Dedicated Server Container Manager (長い...)) は、 [Bedrock Dedicated Server](https://www.minecraft.net/en-us/download/server/bedrock) (以下、 BDS)を手間をかけずに構築・運用する為のスクリプト及び Python モジュールです。
 
 Pymcbdsc には次の特徴があります。

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY ${BEDROCK_SERVER_DIR}/bedrock-server-${BEDROCK_SERVER_VER}.zip .
 RUN mkdir -pv /usr/local/src/bedrock && unzip bedrock-server-$BEDROCK_SERVER_VER.zip -d /usr/local/src/bedrock
 
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ENV LD_LIBRARY_PATH=/opt/bedrock
 RUN apt-get update && apt-get install -y \
   libcurl4

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,4 +58,4 @@ do
   [ ! -L ./${__file} ] && ln -s /volume/${__file} ./${__file}
 done
 
-./${BEDROCK_SERVER_BIN:-"bedrock_server"}
+exec ./${BEDROCK_SERVER_BIN:-"bedrock_server"}

--- a/pymcbdsc/__init__.py
+++ b/pymcbdsc/__init__.py
@@ -13,7 +13,7 @@ from os import name as os_name
 from logging import getLogger
 
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 logger = getLogger(__name__)
 bds_version_pat = "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+"
@@ -549,20 +549,24 @@ class McbdscDockerContainer(object):
         self._name = name
         self._container = container
 
-    def start(self):
-        pass
+    def start(self, **kwargs):
+        container = self._container
+        container.start(**kwargs)
 
-    def stop(self):
-        pass
+    def stop(self, **kwargs):
+        container = self._container
+        container.stop(**kwargs)
 
-    def run(self):
-        pass
+    def restart(self, **kwargs):
+        container = self._container
+        container.restart(**kwargs)
 
     def remove(self):
         pass
 
-    def status(self):
-        pass
+    def stats(self, **kwargs):
+        container = self._container
+        container.stats(**kwargs)
 
     def backup(self, online=False):
         pass

--- a/pymcbdsc/__main__.py
+++ b/pymcbdsc/__main__.py
@@ -82,6 +82,13 @@ def create(args: Namespace, downloader: McbdscDownloader) -> None:
     manager.factory_containers()
 
 
+def start(args: Namespace, downloader: McbdscDownloader) -> None:
+    root_dir = args.root_dir
+    containers_params = [{"name": "mbdsc_test", "image": "bedrock:latest"}]
+    manager = McbdscDockerManager(pymcbdsc_root_dir=root_dir, containers_param=containers_params)
+    manager.factory_containers()[0].start()
+
+
 def parse_args() -> Namespace:
     """ 引数の定義と、解析を行う関数。
 
@@ -120,6 +127,10 @@ def parse_args() -> Namespace:
                                           help="TODO")
     subcmd_create.set_defaults(func=create)
 
+    subcmd_start = subparsers.add_parser("start", parents=[common_parser],
+                                         help="TODO")
+    subcmd_start.set_defaults(func=start)
+
     # 以下、ヘルプコマンドの定義。
 
     # "help" 以外の subcommand のリストを保持する。
@@ -147,7 +158,7 @@ def main():
     if args.debug:
         logger.info("Set log level to DEBUG.")
         logger.setLevel(DEBUG)
-    if args.subcommand in ["install", "download", "build", "create"]:
+    if args.subcommand in ["install", "download", "build", "create", "start"]:
         dl = McbdscDownloader(pymcbdsc_root_dir=args.root_dir, agree_to_meula_and_pp=args.i_agree_to_meula_and_pp)
         args.func(args, dl)
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,11 @@ url = https://github.com/ktooi/pymcbdsc
 license_files = LICENSE
 classifier =
     License :: OSI Approved :: MIT License
-    Development Status :: 1 - Planning
+    Development Status :: 3 - Alpha
     Programming Language :: Python
     Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    Operating System :: Microsoft :: Windows
     Operating System :: POSIX
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
@@ -25,6 +27,7 @@ classifier =
 [options]
 zip_safe = False
 packages = find:
+python_requires = >= 3.5
 install_requires =
   docker >= 4.4.0
 entry_points = file: entry_points.cfg


### PR DESCRIPTION
*   README.md にバッジを追加。
*   Unittest の実行方法を変更。
*   コンテナのベースイメージを Ubuntu:20.04 に変更。
*   BDS サーバにシグナル等が渡るように exec を追加。
*   BDS サーバを起動できる機能の基本部分を実装。
*   パッケージの情報を更新。